### PR TITLE
Refactor Thumbnail struct.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,7 +4681,9 @@ dependencies = [
  "components",
  "gpui",
  "gstreamer",
+ "image",
  "rfd",
+ "smallvec",
 ]
 
 [[package]]

--- a/crates/backend/src/gstreamer/mod.rs
+++ b/crates/backend/src/gstreamer/mod.rs
@@ -5,10 +5,9 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use gstreamer::{ClockTime, MessageView, SeekFlags, State, prelude::*};
 use gstreamer_pbutils as gst_pbutils;
-use image::{EncodableLayout, Frame, ImageReader, Rgba, RgbaImage, imageops::thumbnail};
-use smallvec::SmallVec;
+use image::{EncodableLayout, ImageReader, Rgba, RgbaImage};
 use std::{
-    io::{Cursor, Read},
+    io::Cursor,
     sync::{Arc, Mutex},
 };
 
@@ -207,7 +206,6 @@ fn retrieve_thumbnail(bytes: Box<[u8]>) -> anyhow::Result<Thumbnail> {
     }
 
     Ok(Thumbnail {
-        // img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, width, height))]),
         img: bgra_image.as_raw().clone(),
         width,
         height,
@@ -229,7 +227,6 @@ fn retrieve_small_thumbnail(bytes: Box<[u8]>) -> anyhow::Result<Thumbnail> {
     }
 
     Ok(Thumbnail {
-        // img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, 64, 64))]),
         img: bgra_image.as_raw().clone(),
         width: 64,
         height: 64,

--- a/crates/backend/src/gstreamer/mod.rs
+++ b/crates/backend/src/gstreamer/mod.rs
@@ -8,7 +8,7 @@ use gstreamer_pbutils as gst_pbutils;
 use image::{EncodableLayout, Frame, ImageReader, Rgba, RgbaImage, imageops::thumbnail};
 use smallvec::SmallVec;
 use std::{
-    io::Cursor,
+    io::{Cursor, Read},
     sync::{Arc, Mutex},
 };
 
@@ -207,7 +207,8 @@ fn retrieve_thumbnail(bytes: Box<[u8]>) -> anyhow::Result<Thumbnail> {
     }
 
     Ok(Thumbnail {
-        img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, width, height))]),
+        // img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, width, height))]),
+        img: bgra_image.as_raw().clone(),
         width,
         height,
     })
@@ -228,7 +229,8 @@ fn retrieve_small_thumbnail(bytes: Box<[u8]>) -> anyhow::Result<Thumbnail> {
     }
 
     Ok(Thumbnail {
-        img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, 64, 64))]),
+        // img: SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, 64, 64))]),
+        img: bgra_image.as_raw().clone(),
         width: 64,
         height: 64,
     })

--- a/crates/backend/src/player.rs
+++ b/crates/backend/src/player.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use gstreamer::State;
-use image::{Frame, RgbaImage};
+use image::{Frame, RgbaImage, imageops::thumbnail};
 use ring_channel::{RingReceiver as Receiver, RingSender as Sender};
 use smallvec::SmallVec;
 
@@ -459,7 +459,6 @@ impl Thumbnail {
     pub fn to_frame(&self) -> SmallVec<[Frame; 1]> {
         let img = RgbaImage::from_raw(self.width, self.height, self.img.clone())
             .expect("Failed to reconstruct image from raw bytes");
-        Frame::new(img)
-        SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, width, height))])
+        SmallVec::from_vec(vec![Frame::new(thumbnail(&img, self.width, self.height))])
     }
 }

--- a/crates/backend/src/player.rs
+++ b/crates/backend/src/player.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use gstreamer::State;
-use image::Frame;
+use image::{Frame, RgbaImage};
 use ring_channel::{RingReceiver as Receiver, RingSender as Sender};
 use smallvec::SmallVec;
 
@@ -68,7 +68,7 @@ pub struct Controller {
 
 #[derive(Clone)]
 pub struct Thumbnail {
-    pub img: SmallVec<[Frame; 1]>,
+    pub img: Vec<u8>,
     pub width: u32,
     pub height: u32,
 }
@@ -452,5 +452,14 @@ impl Controller {
         self.tx
             .send(Command::RetrieveSavedPlaylists)
             .expect("Could not send command");
+    }
+}
+
+impl Thumbnail {
+    pub fn to_frame(&self) -> SmallVec<[Frame; 1]> {
+        let img = RgbaImage::from_raw(self.width, self.height, self.img.clone())
+            .expect("Failed to reconstruct image from raw bytes");
+        Frame::new(img)
+        SmallVec::from_vec(vec![Frame::new(thumbnail(&bgra_image, width, height))])
     }
 }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -10,3 +10,5 @@ components = { path = "../components" }
 backend = { path = "../backend" }
 gstreamer.workspace = true
 rfd.workspace = true
+image.workspace = true
+smallvec.workspace = true

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -186,7 +186,7 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                 this.now_playing.update(cx, |np, cx| {
                                     np.update_thumbnail(cx, Thumbnail {
                                         img: ImageSource::Render(
-                                            RenderImage::new(thumbnail.img.clone()).into(),
+                                            RenderImage::new(thumbnail.clone().to_frame()).into(),
                                         ),
                                         width: thumbnail.width,
                                         height: thumbnail.height,

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -53,7 +53,7 @@ impl Render for QueueList {
                         .child({
                             if let Some(thumbnail) = track.thumbnail.clone() {
                                 img(ImageSource::Render(
-                                    RenderImage::new(thumbnail.img.clone()).into(),
+                                    RenderImage::new(thumbnail.to_frame()).into(),
                                 ))
                                 .min_h(px(56.0))
                                 .min_w(px(56.0))


### PR DESCRIPTION
This PR refactors the `Thumbnail` struct so that a `Vec<u8>` containing bytes of the image is stored instead of a `SmallVec<[Frame; 1]>`. This allows the `Playlist` and `Track` structs to be Serialized/Deserialized by Serde, which is needed for caching the playlist and storing it using `bincode`.