### PR TITLE
Implement playlist caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bincode",
  "directories",
  "gpui",
  "gstreamer",
@@ -356,6 +357,24 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "2.0.0-rc.3"
+source = "git+https://github.com/bincode-org/bincode?branch=trunk#0ab1f715ae824b84010f0d020a0ecd47227223e2"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.0-rc.3"
+source = "git+https://github.com/bincode-org/bincode?branch=trunk#0ab1f715ae824b84010f0d020a0ecd47227223e2"
+dependencies = [
+ "virtue",
+]
 
 [[package]]
 name = "bindgen"
@@ -4753,6 +4772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unty"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1a88342087869553c259588a3ec9ca73ce9b2d538b7051ba5789ff236b6c129"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4905,6 +4930,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vswhom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,6 @@ rfd = "0.15.2"
 serde = "1.0.217"
 directories = "5.0"
 toml = "0.8.20"
-bincode = { git = "https://github.com/bincode-org/bincode", branch = "trunk" }
+bincode = { git = "https://github.com/bincode-org/bincode", branch = "trunk", features = [
+    "serde",
+] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ rfd = "0.15.2"
 serde = "1.0.217"
 directories = "5.0"
 toml = "0.8.20"
+bincode = { git = "https://github.com/bincode-org/bincode", branch = "trunk" }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -17,3 +17,4 @@ rfd.workspace = true
 serde.workspace = true
 directories.workspace = true
 toml.workspace = true
+bincode.workspace = true

--- a/crates/backend/src/playback.rs
+++ b/crates/backend/src/playback.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{Backend, player::Thumbnail};
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Track {
     pub title: String,
     pub artists: Vec<String>,
@@ -20,7 +20,7 @@ pub struct Track {
     pub thumbnail: Option<Thumbnail>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Playlist {
     pub name: String,
     pub tracks: Vec<Track>,

--- a/crates/backend/src/playback.rs
+++ b/crates/backend/src/playback.rs
@@ -1,10 +1,11 @@
 use std::{
-    fs,
+    fs::{self, File},
     io::{self, Write},
     path::PathBuf,
     sync::Arc,
 };
 
+use bincode::config;
 use directories::UserDirs;
 use serde::{Deserialize, Serialize};
 
@@ -111,7 +112,23 @@ impl Playlist {
         Ok(())
     }
 
-    pub async fn cache(&self, cached_name: String) -> anyhow::Result<()> {
+    pub async fn write_cached(
+        &self,
+        playlist: Playlist,
+        cached_name: String,
+    ) -> anyhow::Result<()> {
+        let cached_path = UserDirs::new()
+            .unwrap()
+            .audio_dir()
+            .unwrap_or(UserDirs::new().unwrap().home_dir())
+            .join("Reyvr")
+            .join(cached_name);
+        println!("cached: {:#?}", cached_path.clone());
+
+        let mut cached_file = File::create(cached_path)?;
+        let serialized = &bincode::serde::encode_to_vec(playlist, config::standard())?;
+        cached_file.write(serialized)?;
+
         Ok(())
     }
 }

--- a/crates/backend/src/playback.rs
+++ b/crates/backend/src/playback.rs
@@ -5,7 +5,7 @@ use std::{
     sync::Arc,
 };
 
-use directories::BaseDirs;
+use directories::UserDirs;
 use serde::{Deserialize, Serialize};
 
 use crate::{Backend, player::Thumbnail};
@@ -110,6 +110,10 @@ impl Playlist {
         backend.load(&current_song.uri).await?;
         Ok(())
     }
+
+    pub async fn cache(&self, cached_name: String) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 impl SavedPlaylists {
@@ -117,8 +121,11 @@ impl SavedPlaylists {
         SavedPlaylists { playlists: vec![] }
     }
     pub fn get_playlists_file() -> Option<PathBuf> {
-        if let Some(base_dir) = BaseDirs::new() {
-            let proj_dir = base_dir.preference_dir().join("Reyvr");
+        if let Some(user_dirs) = UserDirs::new() {
+            let proj_dir = user_dirs
+                .audio_dir()
+                .unwrap_or(user_dirs.home_dir())
+                .join("Reyvr");
             if let Err(e) = fs::create_dir_all(proj_dir.clone()) {
                 eprintln!("Could not create config directory: {}", e);
                 return None;

--- a/crates/backend/src/playback.rs
+++ b/crates/backend/src/playback.rs
@@ -120,7 +120,6 @@ impl Playlist {
             .join("Reyvr")
             .join("cache")
             .join(cached_name);
-        println!("cached: {:#?}", cached_path.clone());
 
         let mut cached_file = File::create(cached_path)?;
         let serialized = &bincode::serde::encode_to_vec(self, config::standard())?;
@@ -137,7 +136,6 @@ impl Playlist {
             .join("Reyvr")
             .join("cache")
             .join(cached_name);
-        println!("cached: {:#?}", cached_path.clone());
 
         if cached_path.exists() {
             let cached_data = &fs::read(cached_path).expect("Could not read file");

--- a/crates/backend/src/player.rs
+++ b/crates/backend/src/player.rs
@@ -7,9 +7,8 @@ use std::{
 use gstreamer::State;
 use image::{Frame, RgbaImage, imageops::thumbnail};
 use ring_channel::{RingReceiver as Receiver, RingSender as Sender};
-use smallvec::SmallVec;
 use serde::{Deserialize, Serialize};
-
+use smallvec::SmallVec;
 
 use crate::{
     Backend,
@@ -321,7 +320,7 @@ impl Player {
                             let new_saved_playlist = SavedPlaylist {
                                 name,
                                 actual_path: path.to_string_lossy().to_string(),
-                                cached_name,
+                                cached_name: cached_name.clone(),
                             };
                             let mut playlist =
                                 Playlist::from_dir(&backend, PathBuf::from(path.clone())).await;
@@ -331,7 +330,11 @@ impl Player {
                                 .expect("Could not load first item");
 
                             self.loaded = true;
-                            self.playlist = Arc::new(Mutex::new(playlist));
+                            self.playlist = Arc::new(Mutex::new(playlist.clone()));
+                            playlist
+                                .write_cached(cached_name)
+                                .await
+                                .expect("Could not write cache");
 
                             if !self
                                 .saved_playlists

--- a/crates/backend/src/player.rs
+++ b/crates/backend/src/player.rs
@@ -8,6 +8,8 @@ use gstreamer::State;
 use image::{Frame, RgbaImage, imageops::thumbnail};
 use ring_channel::{RingReceiver as Receiver, RingSender as Sender};
 use smallvec::SmallVec;
+use serde::{Deserialize, Serialize};
+
 
 use crate::{
     Backend,
@@ -66,7 +68,7 @@ pub struct Controller {
     pub rx: Receiver<Response>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct Thumbnail {
     pub img: Vec<u8>,
     pub width: u32,

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -39,7 +39,6 @@ impl Render for LeftSidebar {
                     let controller = controller.clone();
                     let curr_index = current_index.clone();
                     let current_index = *curr_index.read(cx);
-                    let path = playlist.actual_path.clone();
 
                     div()
                         .bg(theme.background)
@@ -63,7 +62,7 @@ impl Render for LeftSidebar {
                                 curr_index.update(cx, |this, _| {
                                     *this = index;
                                 });
-                                controller.load(path.clone());
+                                controller.load(playlist.clone());
                                 controller.get_queue();
                             }
                         })


### PR DESCRIPTION
This PR implements a pretty important feature for any music player - caching. Previously we had to read each file in local playlist and extract the metadata every time the user opened that playlist. Now this is only done. Once loaded, the data is stored in a `bincode`-compatible binary file. That is then loaded the next time the user requests this. The loading times have gone from almost 150s to just 120ms. And the file size is also incredibly small. Was pretty easy to implement.