### PR TITLE
Fix lag and current playlist highlight

### DIFF
--- a/crates/backend/src/player.rs
+++ b/crates/backend/src/player.rs
@@ -45,6 +45,7 @@ pub enum Response {
     Thumbnail(Thumbnail),
     Tracks(Vec<Track>),
     SavedPlaylists(SavedPlaylists),
+    PlaylistName(String),
 }
 
 #[derive(Clone)]
@@ -304,7 +305,10 @@ impl Player {
                             .await
                             .expect("Could not load first item");
                         self.loaded = true;
-                        self.playlist = Arc::new(Mutex::new(playlist));
+                        self.playlist = Arc::new(Mutex::new(playlist.clone()));
+                        self.tx
+                            .send(Response::PlaylistName(playlist.name))
+                            .expect("Could not send message");
                     }
                     Command::LoadFolder => {
                         let backend = self.backend.clone();
@@ -346,6 +350,9 @@ impl Player {
                                 .write_cached(cached_name)
                                 .await
                                 .expect("Could not write cache");
+                            self.tx
+                                .send(Response::PlaylistName(playlist.name))
+                                .expect("Could not send message");
 
                             if !self
                                 .saved_playlists

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -155,6 +155,12 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                     });
                                     cx.notify();
                                 }
+                                NowPlayingEvent::PlaylistName(name) => {
+                                    this.now_playing.update(cx, |this, _| {
+                                        this.playlist_name = name.into();
+                                    });
+                                    cx.notify();
+                                }
                             }
                         },
                     )
@@ -224,6 +230,11 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                 saved_playlists.update(cx, |this, _| {
                                     *this = playlists.clone();
                                 })
+                            }
+                            Response::PlaylistName(name) => {
+                                this.now_playing.update(cx, |np, cx| {
+                                    np.update_playlist_name(cx, name.clone());
+                                });
                             }
                             _ => {}
                         },

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -248,8 +248,9 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                     let main_view = cx.new(|_| MainView::new(np.clone(), layout.clone()));
                     let queue_list = cx.new(|_| QueueList::new(np.clone(), layout.clone()));
                     let layout_sidebar = layout.clone();
-                    let left_sidebar = cx.new(move |cx| {
-                        LeftSidebar::new(cx, playlists.clone(), layout_sidebar.clone())
+                    let np_sidebar = np.clone();
+                    let left_sidebar = cx.new(move |_| {
+                        LeftSidebar::new(playlists.clone(), layout_sidebar.clone(), np_sidebar)
                     });
                     cx.global::<Controller>().load_saved_playlists();
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -24,7 +24,7 @@ use control_bar::ControlBar;
 use gpui::*;
 use layout::Layout;
 use main_view::MainView;
-use now_playing::{NowPlaying, NowPlayingEvent, Thumbnail};
+use now_playing::{NowPlaying, NowPlayingEvent, Thumbnail, Track};
 use queue_list::QueueList;
 use res_handler::ResHandler;
 use sidebar::LeftSidebar;
@@ -199,7 +199,26 @@ pub fn run_app(backend: Arc<dyn Backend>) -> anyhow::Result<()> {
                                 });
                             }
                             Response::Tracks(tracks) => this.now_playing.update(cx, |np, cx| {
-                                np.update_tracks(cx, tracks.clone());
+                                let mut np_tracks = vec![];
+                                for track in tracks {
+                                    if let Some(thumbnail) = track.thumbnail.clone() {
+                                        np_tracks.push(Track {
+                                            album: track.album.clone(),
+                                            artists: track.artists.clone(),
+                                            duration: track.duration,
+                                            thumbnail: Some(Thumbnail {
+                                                img: ImageSource::Render(
+                                                    RenderImage::new(thumbnail.to_frame()).into(),
+                                                ),
+                                                width: thumbnail.width,
+                                                height: thumbnail.height,
+                                            }),
+                                            title: track.title.clone(),
+                                            uri: track.uri.clone(),
+                                        });
+                                    }
+                                }
+                                np.update_tracks(cx, np_tracks);
                             }),
                             Response::SavedPlaylists(playlists) => {
                                 saved_playlists.update(cx, |this, _| {

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -39,6 +39,7 @@ pub enum NowPlayingEvent {
     State(State),
     Volume(f64),
     Tracks(Vec<Track>),
+    PlaylistName(String),
 }
 
 impl NowPlaying {
@@ -91,6 +92,11 @@ impl NowPlaying {
 
     pub fn update_tracks(&mut self, cx: &mut Context<Self>, tracks: Vec<Track>) {
         cx.emit(NowPlayingEvent::Tracks(tracks));
+        cx.notify();
+    }
+
+    pub fn update_playlist_name(&mut self, cx: &mut Context<Self>, name: String) {
+        cx.emit(NowPlayingEvent::PlaylistName(name));
         cx.notify();
     }
 }

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -3,6 +3,7 @@ use gstreamer::State;
 
 #[derive(Clone)]
 pub struct NowPlaying {
+    pub playlist_name: SharedString,
     pub title: SharedString,
     pub album: SharedString,
     pub artists: Vec<SharedString>,
@@ -43,6 +44,7 @@ pub enum NowPlayingEvent {
 impl NowPlaying {
     pub fn new() -> Self {
         NowPlaying {
+            playlist_name: "".into(),
             title: "".into(),
             artists: vec!["".into()],
             album: "".into(),

--- a/crates/ui/src/now_playing.rs
+++ b/crates/ui/src/now_playing.rs
@@ -1,4 +1,3 @@
-use backend::playback::Track;
 use gpui::*;
 use gstreamer::State;
 
@@ -20,6 +19,16 @@ pub struct Thumbnail {
     pub img: ImageSource,
     pub width: u32,
     pub height: u32,
+}
+
+#[derive(Clone)]
+pub struct Track {
+    pub title: String,
+    pub artists: Vec<String>,
+    pub album: String,
+    pub uri: String,
+    pub duration: u64,
+    pub thumbnail: Option<Thumbnail>,
 }
 
 pub enum NowPlayingEvent {

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -52,12 +52,10 @@ impl Render for QueueList {
                         })
                         .child({
                             if let Some(thumbnail) = track.thumbnail.clone() {
-                                img(ImageSource::Render(
-                                    RenderImage::new(thumbnail.to_frame()).into(),
-                                ))
-                                .min_h(px(56.0))
-                                .min_w(px(56.0))
-                                .rounded_md()
+                                img(thumbnail.img)
+                                    .min_h(px(56.0))
+                                    .min_w(px(56.0))
+                                    .rounded_md()
                             } else {
                                 img("")
                             }

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -2,12 +2,15 @@ use backend::{playback::SavedPlaylists, player::Controller};
 use components::theme::Theme;
 use gpui::{prelude::FluentBuilder, *};
 
-use crate::layout::{Layout, LayoutMode};
+use crate::{
+    layout::{Layout, LayoutMode},
+    now_playing::NowPlaying,
+};
 
 #[derive(Clone)]
 pub struct LeftSidebar {
     pub playlists: Entity<SavedPlaylists>,
-    pub active_index: Entity<String>,
+    pub now_playing: Entity<NowPlaying>,
     pub layout: Entity<Layout>,
 }
 
@@ -16,7 +19,7 @@ impl Render for LeftSidebar {
         let theme = cx.global::<Theme>();
         let controller = cx.global::<Controller>().clone();
         let playlists = self.playlists.read(cx).clone().playlists;
-        let current_index = self.active_index.clone();
+        let current_index = self.now_playing.clone();
         let layout = self.layout.clone().read(cx);
 
         if layout.left_sidebar.show {
@@ -38,7 +41,7 @@ impl Render for LeftSidebar {
                 .children(playlists.into_iter().map(|playlist| {
                     let controller = controller.clone();
                     let curr_index = current_index.clone();
-                    let current_index = curr_index.read(cx);
+                    let current_index = curr_index.read(cx).playlist_name.clone();
 
                     div()
                         .bg(theme.background)
@@ -61,8 +64,8 @@ impl Render for LeftSidebar {
                         .truncate()
                         .on_mouse_down(MouseButton::Left, {
                             move |_, _, cx| {
-                                curr_index.update(cx, |this, _| {
-                                    *this = playlist.name.clone();
+                                curr_index.update(cx, |this, cx| {
+                                    this.update_playlist_name(cx, playlist.name.clone());
                                 });
                                 controller.load(playlist.clone());
                                 controller.get_queue();
@@ -96,11 +99,15 @@ impl Render for LeftSidebar {
 }
 
 impl LeftSidebar {
-    pub fn new(cx: &mut App, playlists: Entity<SavedPlaylists>, layout: Entity<Layout>) -> Self {
+    pub fn new(
+        playlists: Entity<SavedPlaylists>,
+        layout: Entity<Layout>,
+        now_playing: Entity<NowPlaying>,
+    ) -> Self {
         LeftSidebar {
             playlists,
-            active_index: cx.new(|_| String::new()),
             layout,
+            now_playing,
         }
     }
 }

--- a/crates/ui/src/sidebar.rs
+++ b/crates/ui/src/sidebar.rs
@@ -7,7 +7,7 @@ use crate::layout::{Layout, LayoutMode};
 #[derive(Clone)]
 pub struct LeftSidebar {
     pub playlists: Entity<SavedPlaylists>,
-    pub active_index: Entity<usize>,
+    pub active_index: Entity<String>,
     pub layout: Entity<Layout>,
 }
 
@@ -35,17 +35,19 @@ impl Render for LeftSidebar {
                 .flex()
                 .flex_col()
                 .gap_2()
-                .children(playlists.into_iter().enumerate().map(|(index, playlist)| {
+                .children(playlists.into_iter().map(|playlist| {
                     let controller = controller.clone();
                     let curr_index = current_index.clone();
-                    let current_index = *curr_index.read(cx);
+                    let current_index = curr_index.read(cx);
 
                     div()
                         .bg(theme.background)
                         .border_1()
                         .border_color(theme.secondary)
                         .hover(|this| this.border_color(theme.accent))
-                        .when(index == current_index, |this| this.bg(theme.secondary))
+                        .when(playlist.name == current_index.clone(), |this| {
+                            this.bg(theme.secondary)
+                        })
                         .text_color(theme.text)
                         .font_weight(FontWeight::MEDIUM)
                         .w_full()
@@ -60,7 +62,7 @@ impl Render for LeftSidebar {
                         .on_mouse_down(MouseButton::Left, {
                             move |_, _, cx| {
                                 curr_index.update(cx, |this, _| {
-                                    *this = index;
+                                    *this = playlist.name.clone();
                                 });
                                 controller.load(playlist.clone());
                                 controller.get_queue();
@@ -97,7 +99,7 @@ impl LeftSidebar {
     pub fn new(cx: &mut App, playlists: Entity<SavedPlaylists>, layout: Entity<Layout>) -> Self {
         LeftSidebar {
             playlists,
-            active_index: cx.new(|_| 1),
+            active_index: cx.new(|_| String::new()),
             layout,
         }
     }


### PR DESCRIPTION
This PR fixes an issue created by PR #4 where the thumbnail bytes were converted to a `SmallVec<[Frame;1]>` and further to a `gpui::ImageSource` each render. This caused massive performance issues.

also, now when opening a folder that was previously saved, the opened playlist is highlighted in the sidebar.