### PR TITLE
refactor: use UniformList

### DIFF
--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -34,7 +34,7 @@ impl Render for QueueList {
                         cx.entity(),
                         "queue_list",
                         tracks.len(),
-                        move |_this, range, _window, cx| {
+                        move |_, range, _, cx| {
                             let theme = cx.global::<Theme>();
 
                             range
@@ -57,7 +57,7 @@ impl Render for QueueList {
                                         .hover(|this| this.bg(theme.secondary))
                                         .on_mouse_down(MouseButton::Left, move |_, _, cx| {
                                             let controller = cx.global::<Controller>().clone();
-                                            controller.play_id(id);
+                                            controller.play_id(id + 1);
                                         })
                                         .child({
                                             if let Some(thumbnail) = &track.thumbnail {

--- a/crates/ui/src/queue_list.rs
+++ b/crates/ui/src/queue_list.rs
@@ -29,64 +29,78 @@ impl Render for QueueList {
                 })
                 .border_l_1()
                 .border_color(theme.secondary)
-                .id("scrollview")
-                .overflow_y_scroll()
-                .children(tracks.into_iter().enumerate().map(|(id, track)| {
-                    div()
-                        .w_full()
-                        .h_16()
-                        .flex()
-                        .px_3()
-                        .gap_2()
-                        .text_color(theme.text)
-                        .items_center()
-                        .justify_between()
-                        .px_2()
-                        .border_b_1()
-                        .border_color(theme.secondary)
-                        .rounded_md()
-                        .hover(|this| this.bg(theme.secondary))
-                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
-                            let controller = cx.global::<Controller>().clone();
-                            controller.play_id(id);
-                        })
-                        .child({
-                            if let Some(thumbnail) = track.thumbnail.clone() {
-                                img(thumbnail.img)
-                                    .min_h(px(56.0))
-                                    .min_w(px(56.0))
-                                    .rounded_md()
-                            } else {
-                                img("")
-                            }
-                        })
-                        .child(
-                            div()
-                                .w_full()
-                                .h(px(56.0))
-                                .flex()
-                                .flex_col()
-                                .gap(px(1.0))
-                                .child(
+                .child(
+                    uniform_list(
+                        cx.entity(),
+                        "queue_list",
+                        tracks.len(),
+                        move |_this, range, _window, cx| {
+                            let theme = cx.global::<Theme>();
+
+                            range
+                                .map(|id| {
+                                    let track = &tracks[id];
+
                                     div()
-                                        .child(track.title.clone())
-                                        .truncate()
-                                        .text_ellipsis()
-                                        .text_base()
-                                        .font_weight(FontWeight::MEDIUM),
-                                )
-                                .child(
-                                    div()
-                                        .child(track.artists.join(", "))
-                                        .truncate()
-                                        .text_ellipsis()
-                                        .text_sm()
-                                        .font_weight(FontWeight::NORMAL),
-                                ),
-                        )
-                }))
+                                        .w_full()
+                                        .h_16()
+                                        .flex()
+                                        .px_3()
+                                        .gap_2()
+                                        .text_color(theme.text)
+                                        .items_center()
+                                        .justify_between()
+                                        .px_2()
+                                        .border_b_1()
+                                        .border_color(theme.secondary)
+                                        .rounded_md()
+                                        .hover(|this| this.bg(theme.secondary))
+                                        .on_mouse_down(MouseButton::Left, move |_, _, cx| {
+                                            let controller = cx.global::<Controller>().clone();
+                                            controller.play_id(id);
+                                        })
+                                        .child({
+                                            if let Some(thumbnail) = &track.thumbnail {
+                                                img(thumbnail.img.clone())
+                                                    .min_h(px(56.0))
+                                                    .min_w(px(56.0))
+                                                    .rounded_md()
+                                            } else {
+                                                img("")
+                                            }
+                                        })
+                                        .child(
+                                            div()
+                                                .w_full()
+                                                .h(px(56.0))
+                                                .flex()
+                                                .flex_col()
+                                                .gap(px(1.0))
+                                                .child(
+                                                    div()
+                                                        .child(track.title.clone())
+                                                        .truncate()
+                                                        .text_ellipsis()
+                                                        .text_base()
+                                                        .font_weight(FontWeight::MEDIUM),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .child(track.artists.join(", "))
+                                                        .truncate()
+                                                        .text_ellipsis()
+                                                        .text_sm()
+                                                        .font_weight(FontWeight::NORMAL),
+                                                ),
+                                        )
+                                })
+                                .collect()
+                        },
+                    )
+                    .h_full(),
+                )
         } else {
-            div().id("")
+            div()
         }
     }
 }


### PR DESCRIPTION
This PR uses a `UniformList` in place of the previous `Div` with `overflow_y_scroll`. This virtualizes items which are not rendered, improving performance.